### PR TITLE
プロジェクト内のすべてのJavaソースコード（プロダクションコードおよびテストコード）に対して、詳細な日本語のJavadocコメントを追記…

### DIFF
--- a/app/src/main/java/imaizm/imagebundler/Constants.java
+++ b/app/src/main/java/imaizm/imagebundler/Constants.java
@@ -1,11 +1,20 @@
 package imaizm.imagebundler;
 
+/**
+ * アプリケーション全体で使用する定数を定義するクラスです。
+ */
 public class Constants {
-	/** アプリケーション名 */
+	/**
+	 * アプリケーション名です。
+	 */
 	public static final String APPLICATION_NAME = "ImageBundler";
-	/** リターンコード：正常終了時（0） */
+	/**
+	 * リターンコード：正常終了時（0）です。
+	 */
 	public static final int RETURN_CODE_NORMAL = 0;
-	/** リターンコード：以上終了時（1） */
+	/**
+	 * リターンコード：異常終了時（1）です。
+	 */
 	public static final int RETURN_CODE_ERROR = 1;
 
 }

--- a/app/src/main/java/imaizm/imagebundler/EntryPoint.java
+++ b/app/src/main/java/imaizm/imagebundler/EntryPoint.java
@@ -29,14 +29,42 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.io.FilenameUtils;
 
+/**
+ * 画像ファイルを指定された幅と高さに変換し、JPEG形式で圧縮してZIPファイルに格納するエントリーポイントクラスです。
+ * <p>
+ * 主な機能は以下の通りです。
+ * <ul>
+ *   <li>指定された画像ファイルまたはディレクトリ内の画像ファイルを処理します。</li>
+ *   <li>画像をリサイズし、JPEG形式に変換します。</li>
+ *   <li>変換後の画像を一時ディレクトリに保存します。</li>
+ *   <li>一時ディレクトリ内の画像をZIPファイルにまとめて格納します。</li>
+ *   <li>処理の進捗状況をプログレスモニターで表示します。</li>
+ * </ul>
+ * コマンドライン引数またはファイル選択ダイアログを通じて処理対象を指定できます。
+ * </p>
+ */
 public class EntryPoint {
 
 	/**
-	 * デフォルトコンストラクタ
+	 * {@code EntryPoint} オブジェクトを構築します。
+	 * このコンストラクタは、インスタンスの初期化のみを行い、特定の処理は実行しません。
 	 */
 	public EntryPoint() {
 	}
 
+	/**
+	 * 指定された入力ファイルまたはディレクトリ内の画像ファイルを処理し、指定された幅と高さに変換します。
+	 * <p>
+	 * 入力パスがファイルの場合、そのファイルを変換します。
+	 * 入力パスがディレクトリの場合、ディレクトリ内のサポートされている画像ファイルを変換し、
+	 * 変換後の画像を元のファイル名でZIPファイルに格納します。
+	 * </p>
+	 *
+	 * @param inputFilePath 処理対象のファイルまたはディレクトリのパス。
+	 * @param width 変換後の画像の幅（ピクセル単位）。
+	 * @param height 変換後の画像の高さ（ピクセル単位）。
+	 * @throws IOException ファイルの読み書き中にエラーが発生した場合。
+	 */
 	public void convert(Path inputFilePath, int width, int height)
 		throws IOException {
 		
@@ -61,6 +89,21 @@ public class EntryPoint {
 		inputFileHandler.close();
 	}
 	
+	/**
+	 * 指定された入力ファイルのリストを、指定された幅と高さに変換し、縮小版の画像をZIPファイルに格納します。
+	 * <p>
+	 * このメソッドは、主に {@link #convert(Path, int, int)} メソッドから内部的に呼び出されます。
+	 * 変換処理の進捗はプログレスモニターで表示されます。
+	 * 変換後の画像は一時ディレクトリに保存され、その後ZIPファイルにまとめられます。
+	 * 処理完了後、一時ファイルおよび一時ディレクトリは削除されます。
+	 * </p>
+	 *
+	 * @param inputFilePath 元の入力パス（ファイルまたはディレクトリ）。主にZIPファイル名の生成に使用されます。
+	 * @param inputFilePathList 処理対象の画像ファイルのパスのリスト。
+	 * @param width 変換後の画像の幅（ピクセル単位）。
+	 * @param height 変換後の画像の高さ（ピクセル単位）。
+	 * @throws IOException ファイルの読み書きまたはZIPファイル作成中にエラーが発生した場合。
+	 */
 	private void convert(Path inputFilePath, List<Path> inputFilePathList, int width, int height) throws IOException {
 		
 		Path workDirectoryPath = (new WorkDirectoryHandler()).getWorkDirectoryPath();
@@ -150,6 +193,19 @@ public class EntryPoint {
 	}
 */
 
+	/**
+	 * 指定された {@link BufferedImage} をJPEGファイルとして書き込みます。
+	 * <p>
+	 * 画像が透過情報を持つ場合、透過部分を指定された背景色（デフォルトは白）で塗りつぶしてからJPEGに変換します。
+	 * JPEGの圧縮品質はパーセンテージで指定します。
+	 * </p>
+	 *
+	 * @param inputBufferedImage 書き込む対象の画像データ。
+	 * @param outputFileName 出力するJPEGファイルのパスとファイル名。
+	 * @param compressionQualityPercentage JPEGの圧縮品質（0から100の範囲、100が最高品質）。
+	 * @return 書き込まれたJPEGファイルの {@link Path} オブジェクト。
+	 * @throws IOException ファイル書き込み中にエラーが発生した場合。
+	 */
 	private Path writeJpegFile(
 		BufferedImage inputBufferedImage,
 		String outputFileName,
@@ -173,7 +229,7 @@ public class EntryPoint {
 			ImageWriter imageWriter = imageWriters.next();
 			imageWriter.setOutput(imageOutputStream);
 			ImageWriteParam imageWriteParam = imageWriter.getDefaultWriteParam();
-			imageWriteParam.setCompressionMode(2);
+			imageWriteParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT); // MODE_EXPLICIT = 2
 			imageWriteParam.setCompressionQuality(compressionQuality);
 
 			imageWriter.write(null, new IIOImage(inputBufferedImage, null, null), imageWriteParam);
@@ -185,7 +241,18 @@ public class EntryPoint {
 		return outputFilePath;
 	}
 
-	// 透過情報をfillColorに置き換えたBufferedImageを返却
+	/**
+	 * 指定された {@link BufferedImage} の透過ピクセルを指定された色で塗りつぶします。
+	 * <p>
+	 * 新しい {@code BufferedImage} を {@code BufferedImage.TYPE_INT_RGB} 形式で作成し、
+	 * 指定された {@code fillColor} で背景を塗りつぶした後、元の画像をその上に描画します。
+	 * これにより、元の画像の透過部分は {@code fillColor} で置き換えられます。
+	 * </p>
+	 *
+	 * @param inputBufferdImage 透過ピクセルを塗りつぶす対象の画像。
+	 * @param fillColor 透過ピクセルを塗りつぶすために使用する色。
+	 * @return 透過ピクセルが {@code fillColor} で塗りつぶされた新しい {@link BufferedImage} インスタンス。
+	 */
 	private BufferedImage fillTransparentPixels(
 		BufferedImage inputBufferdImage, 
 		Color fillColor) {
@@ -201,6 +268,19 @@ public class EntryPoint {
 		return outputBufferdImage;
 	}
 	
+	/**
+	 * 指定されたファイルリストをZIPファイルに格納します。
+	 * <p>
+	 * 各ファイルはZIPファイル内のエントリとして、元のファイル名で格納されます。
+	 * ZIP圧縮メソッドはSTORED（無圧縮）を使用し、エンコーディングはMS932（Shift_JIS）です。
+	 * 各エントリには、最終更新日時、サイズ、CRC-32チェックサムが設定されます。
+	 * </p>
+	 *
+	 * @param targetFilePathList ZIPファイルに格納するファイルのパスのリスト。
+	 * @param outputFileName 出力するZIPファイルのパスとファイル名。
+	 * @return 作成されたZIPファイルの {@link Path} オブジェクト。
+	 * @throws IOException ファイルの読み書きまたはZIPファイル作成中にエラーが発生した場合。
+	 */
 	private Path store(List<Path> targetFilePathList, String outputFileName)
 		throws IOException {
 		
@@ -261,6 +341,16 @@ public class EntryPoint {
 		return outputFilePath;
 	}
 	
+	/**
+	 * アプリケーションのメインエントリーポイントです。
+	 * <p>
+	 * コマンドライン引数を受け取り、{@link #execute(String[])} メソッドを呼び出して処理を実行します。
+	 * 処理結果に応じて、適切なリターンコードでアプリケーションを終了します ({@link System#exit(int)})。
+	 * 例外が発生した場合はスタックトレースを出力し、エラーリターンコードで終了します。
+	 * </p>
+	 *
+	 * @param args コマンドライン引数。最初の引数として処理対象のファイルまたはディレクトリのパスを指定できます。
+	 */
 	public static void main(String args[]) {
 		// デフォルトリターンコード＝１
 		int returnCode = Constants.RETURN_CODE_ERROR;
@@ -273,6 +363,26 @@ public class EntryPoint {
 		System.exit(returnCode);
 	}
 
+	/**
+	 * コマンドライン引数に基づいて画像変換処理を実行します。
+	 * <p>
+	 * 引数で処理対象のファイルまたはディレクトリが指定されている場合、それを処理します。
+	 * 引数がない場合は、ファイル選択ダイアログを表示し、ユーザーに処理対象を選択させます。
+	 * 選択された各ファイルまたはディレクトリに対して、{@link #convert(Path, int, int)} メソッドを呼び出し、
+	 * 画像を指定されたサイズ（幅768ピクセル、高さ1024ピクセル）に変換します。
+	 * 処理の全体的な進捗はプログレスモニターで表示されます。
+	 * </p>
+	 * <p>
+	 * ファイル選択ダイアログを使用した場合、最後に選択されたファイルの親ディレクトリが記憶され、
+	 * 次回ダイアログを開く際の初期ディレクトリとして使用されます。
+	 * </p>
+	 *
+	 * @param args コマンドライン引数。最初の引数として処理対象のファイルまたはディレクトリのパスを指定できます。
+	 *             引数が指定されていない場合は、ファイル選択ダイアログが表示されます。
+	 * @return 処理が正常に完了した場合は {@link Constants#RETURN_CODE_NORMAL} (0)、
+	 *         エラーが発生した場合は {@link Constants#RETURN_CODE_ERROR} (1)。
+	 * @throws IOException ファイルの読み書きまたは画像処理中にエラーが発生した場合。
+	 */
 	public static int execute(String args[]) throws IOException {
 		// デフォルトリターンコード＝１
 		int returnCode = Constants.RETURN_CODE_ERROR;

--- a/app/src/main/java/imaizm/imagebundler/IniFileHandler.java
+++ b/app/src/main/java/imaizm/imagebundler/IniFileHandler.java
@@ -7,15 +7,48 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * アプリケーションの設定をINIファイルとして読み書きするクラスです。
+ * <p>
+ * 主に、前回使用された作業ディレクトリのパスをINIファイルに保存し、
+ * 次回起動時にそのパスを読み込むために使用されます。
+ * INIファイルは、アプリケーションの実行ディレクトリに {@code ImageBundler.ini} という名前で作成されます。
+ * </p>
+ */
 public class IniFileHandler {
 	
+	/** INIファイルのパス。 */
 	private Path iniFilePath;
+	/** 前回使用された作業ディレクトリのパス。INIファイルから読み込まれます。 */
 	private Path workDirectoryPathOfLastTime;
 	
+	/**
+	 * INIファイルから読み込まれた前回使用時の作業ディレクトリのパスを取得します。
+	 *
+	 * @return 前回使用時の作業ディレクトリのパス。INIファイルが存在しない、または読み込めない場合はnullになる可能性があります。
+	 */
 	public Path getWorkDirectoryPathOfLastTime() {
 		return this.workDirectoryPathOfLastTime;
 	}
 	
+	/**
+	 * {@code IniFileHandler} オブジェクトを構築し、INIファイルの読み込みまたは新規作成を行います。
+	 * <p>
+	 * 現在の作業ディレクトリ（通常はアプリケーションの実行ディレクトリ）に、
+	 * {@link Constants#APPLICATION_NAME} に ".ini" を付加した名前のINIファイルが存在するか確認します。
+	 * <ul>
+	 *   <li>INIファイルが存在する場合：
+	 *     ファイルから最初の行を読み込み、その行が示すパスを {@link #getCurrentDirectoryPath(String)} メソッドで検証し、
+	 *     結果を {@link #workDirectoryPathOfLastTime} フィールドに設定します。
+	 *   </li>
+	 *   <li>INIファイルが存在しない場合：
+	 *     新しいINIファイルを指定されたパスで作成します。この時点ではファイルは空です。
+	 *   </li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @throws IOException INIファイルの読み込みまたは作成中にI/Oエラーが発生した場合。
+	 */
 	public IniFileHandler() throws IOException {
 		//
 		// ファイル選択ダイアログの起点を定める
@@ -45,10 +78,18 @@ public class IniFileHandler {
 	}
 	
 	/**
-	 * path文字列に指定されたディレクトリパスを検証し、存在すればそのパスのFileオブジェクトを、
-	 * 存在しなければパスを一つづつ遡っていき、最初に発見した存在するパスのFileオブジェクトを返す。
-	 * @param pathString 存在の検証をするパス文字列
-	 * @return 存在したパスのFileオブジェクト
+	 * 指定されたパス文字列を検証し、そのパスまたはその親ディレクトリのいずれかが実際に存在する場合に、
+	 * 存在する最も深い階層の {@link Path} オブジェクトを返します。
+	 * <p>
+	 * まず、指定された {@code pathString} を {@link Path} オブジェクトに変換します。
+	 * 変換されたパスが存在する場合、そのパスをそのまま返します。
+	 * 存在しない場合、パスの親ディレクトリを順に遡っていき、最初に見つかった存在するディレクトリのパスを返します。
+	 * ルートディレクトリまで遡っても有効なパスが見つからない場合（通常はありえませんが）、null を返す可能性があります。
+	 * </p>
+	 *
+	 * @param pathString 検証するディレクトリのパスを表す文字列。
+	 * @return 指定されたパスまたはその親ディレクトリのうち、実際に存在する最も深い階層の {@link Path} オブジェクト。
+	 *         有効なパスが見つからない場合は null またはルートに近い存在するパス。
 	 */
 	private Path getCurrentDirectoryPath(String pathString) {
 
@@ -64,6 +105,17 @@ public class IniFileHandler {
 		return pathForReturn;
 	}
 	
+	/**
+	 * 指定されたファイルパスをINIファイルに書き込みます。
+	 * <p>
+	 * このメソッドは、{@link #iniFilePath} で示されるINIファイルに、
+	 * 指定された {@code filePath} 文字列を上書きで書き込みます。
+	 * これにより、次回アプリケーション起動時にこのパスが読み込まれるようになります。
+	 * </p>
+	 *
+	 * @param filePath INIファイルに書き込む作業ディレクトリのパス文字列。
+	 * @throws IOException INIファイルへの書き込み中にI/Oエラーが発生した場合。
+	 */
 	public void writeWorkDirectoryOfLastTime(String filePath) throws IOException {
 		
 		try (BufferedWriter bufferedWriter = Files.newBufferedWriter(this.iniFilePath)) {

--- a/app/src/main/java/imaizm/imagebundler/InputFileHandler.java
+++ b/app/src/main/java/imaizm/imagebundler/InputFileHandler.java
@@ -8,19 +8,80 @@ import java.nio.file.PathMatcher;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * 入力ファイルまたはディレクトリを処理し、対象となる画像ファイルのリストを管理するクラスです。
+ * <p>
+ * このクラスは、以下の3つのケースで入力ソースを扱います。
+ * <ul>
+ *   <li>入力がディレクトリの場合：ディレクトリ内の画像ファイル（JPG, JPEG, PNG）をリストアップします。</li>
+ *   <li>入力がZIPファイルの場合：ZIPファイルを一時ディレクトリに解凍し、解凍されたファイルの中から画像ファイルをリストアップします。</li>
+ *   <li>上記以外の場合：未対応のファイル形式として実行時例外をスローします。</li>
+ * </ul>
+ * ZIPファイルが処理された場合、{@link #close()} メソッドを呼び出すことで、解凍時に作成された一時ファイルおよびディレクトリが削除されます。
+ * </p>
+ */
 public class InputFileHandler {
 	
+	/** 処理対象となる画像ファイルのパスのリスト。 */
 	private List<Path> inputFilePathList;
+	/**
+	 * 処理対象となる画像ファイルのパスのリストを取得します。
+	 * <p>
+	 * このリストは、コンストラクタで指定された入力ソースに基づいて設定されます。
+	 * 入力ソースがディレクトリの場合はその中の画像ファイル、ZIPファイルの場合は解凍された画像ファイルが含まれます。
+	 * </p>
+	 * @return 処理対象の画像ファイルの {@link Path} のリスト。
+	 */
 	public List<Path> getInputFilePathList() {
 		return this.inputFilePathList;
 	}
 	
+	/** ZIPファイルが入力された場合に、ファイルを解凍するための一時ディレクトリのパス。 */
 	private Path extractDirectoryPath;
+	/**
+	 * ZIPファイルが解凍された一時ディレクトリのパスを取得します。
+	 * <p>
+	 * このパスは、入力ソースがZIPファイルの場合にのみ設定されます。
+	 * それ以外の場合は null になります。
+	 * </p>
+	 * @return ZIP解凍用の一時ディレクトリの {@link Path}。該当しない場合は null。
+	 */
 	public Path getExtractDirectoryPath() {
 		return this.extractDirectoryPath;
 	}
+	/** ZIPファイルが入力された場合に、解凍されたファイルのパスのリスト。 */
 	private List<Path> extractedFilePathList;
 	
+	/**
+	 * {@code InputFileHandler} オブジェクトを構築し、指定された入力パスに基づいて処理対象ファイルを初期化します。
+	 * <p>
+	 * 入力パス {@code inputFilePath} がディレクトリであるか、ZIPファイルであるか、
+	 * またはサポートされていないファイル形式であるかを判断します。
+	 * <ul>
+	 *   <li><b>ディレクトリの場合:</b>
+	 *     指定されたディレクトリ内にあるJPG, JPEG, PNGファイルを検索し、
+	 *     それらのファイルのパスを {@link #inputFilePathList} に格納します。
+	 *     大文字・小文字を区別しないファイル拡張子でマッチングします。
+	 *   </li>
+	 *   <li><b>ZIPファイルの場合:</b>
+	 *     まず、{@link WorkDirectoryHandler} を使用して一時的な作業ディレクトリを作成し、
+	 *     そのパスを {@link #extractDirectoryPath} に格納します。
+	 *     次に、指定されたZIPファイルをこの一時ディレクトリに解凍します（{@link ZipFileHandler#inflate(Path, Path)} を使用）。
+	 *     解凍されたファイルのパスのリストは {@link #extractedFilePathList} に格納され、
+	 *     このリストが {@link #inputFilePathList} としても使用されます。
+	 *   </li>
+	 *   <li><b>上記以外の場合:</b>
+	 *     サポートされていないファイル形式であると判断し、"未対応のファイル形式です。" というメッセージと共に
+	 *     {@link RuntimeException} をスローします。
+	 *   </li>
+	 * </ul>
+	 * ファイル拡張子のマッチングには、大文字・小文字を区別しない正規表現ベースの {@link PathMatcher} を使用します。
+	 * コメントアウトされたglobベースのPathMatcherは現在使用されていません。
+	 * </p>
+	 *
+	 * @param inputFilePath 処理対象のファイルまたはディレクトリのパス。
+	 * @throws IOException ファイルの読み込み、ディレクトリのリスト、またはZIPファイルの解凍中にI/Oエラーが発生した場合。
+	 */
 	public InputFileHandler(Path inputFilePath) throws IOException {
 		
 //		PathMatcher pmZip = FileSystems.getDefault().getPathMatcher("glob:**.zip");
@@ -65,6 +126,28 @@ public class InputFileHandler {
 		}	
 	}
 	
+	/**
+	 * この {@code InputFileHandler} が使用したリソースを解放します。
+	 * <p>
+	 * 主に、入力ソースがZIPファイルであった場合に作成された一時ファイルをクリーンアップするために使用されます。
+	 * <ul>
+	 *   <li>{@link #extractedFilePathList} が null でない場合（つまり、ZIPファイルが解凍された場合）：
+	 *     <ul>
+	 *       <li>{@link #inputFilePathList} を null に設定します。</li>
+	 *       <li>{@link #extractedFilePathList} に含まれるすべての解凍されたファイルを削除します。</li>
+	 *     </ul>
+	 *   </li>
+	 *   <li>{@link #extractDirectoryPath} が null でない場合（つまり、解凍用の一時ディレクトリが作成された場合）：
+	 *     <ul>
+	 *       <li>その一時ディレクトリを削除します。</li>
+	 *     </ul>
+	 *   </li>
+	 * </ul>
+	 * このメソッドは、処理が完了した後、不要になった一時ファイルを確実に削除するために呼び出す必要があります。
+	 * </p>
+	 *
+	 * @throws IOException ファイルまたはディレクトリの削除中にI/Oエラーが発生した場合。
+	 */
 	public void close() throws IOException {
 		if (this.extractedFilePathList != null) {
 			this.inputFilePathList = null;

--- a/app/src/main/java/imaizm/imagebundler/WorkDirectoryHandler.java
+++ b/app/src/main/java/imaizm/imagebundler/WorkDirectoryHandler.java
@@ -8,15 +8,55 @@ import java.text.DecimalFormat;
 import java.time.format.DateTimeFormatter;
 import java.time.LocalDateTime;
 
+/**
+ * アプリケーションの一時的な作業ディレクトリを作成および管理するクラスです。
+ * <p>
+ * このクラスの主な目的は、OSの一時ディレクトリ内に、アプリケーション固有の
+ * 一時作業ディレクトリを安全に作成することです。作業ディレクトリ名は、
+ * 現在の日時とランダムな5桁の数値から生成され、重複のリスクを低減します。
+ * </p>
+ * <p>
+ * 作成された作業ディレクトリのパスは、{@link #getWorkDirectoryPath()} メソッドを通じて取得できます。
+ * このクラスの利用者は、アプリケーション終了時などに、取得したパスを使用して
+ * 作業ディレクトリを適切にクリーンアップする責任があります。
+ * </p>
+ */
 public class WorkDirectoryHandler {
 
-	/** 作業用ディレクトリのパスを格納 */
+	/** 
+	 * OSの一時ディレクトリのパスを格納します。
+	 * このパスは {@code java.io.tmpdir} システムプロパティから取得されます。
+	 */
 	private String tempDirectoryPath;
-	/** 作業量ディレクトリに作成する仮ディレクトリのディレクトリ名を格納 */
+	/** 
+	 * 作成される一時作業ディレクトリの名前を格納します。
+	 * この名前は、現在の日時 (yyyyMMddHHmmss形式) と5桁のランダムな数値から構成されます。
+	 */
 	private String workDirectoryName;
-	/** 仮ディレクトリ操作用のPathオブジェクト*/
+	/** 
+	 * 作成された一時作業ディレクトリへの {@link Path} オブジェクトです。
+	 * このパスは、{@code tempDirectoryPath} と {@code workDirectoryName} を結合して生成されます。
+	 */
 	private Path workDirectoryPath;
 
+	/**
+	 * {@code WorkDirectoryHandler} オブジェクトを構築し、新しい一時作業ディレクトリを作成します。
+	 * <p>
+	 * 処理の流れは以下の通りです。
+	 * <ol>
+	 *   <li>OSの一時ディレクトリのパスを {@code java.io.tmpdir} システムプロパティから取得し、
+	 *       {@link #tempDirectoryPath} に格納します。</li>
+	 *   <li>作成する一時作業ディレクトリの名前を生成します。この名前は、
+	 *       現在の日時（"yyyyMMddHHmmss"形式）と、0から99999までの5桁のランダムな整数を
+	 *       連結したものになります。生成された名前は {@link #workDirectoryName} に格納されます。</li>
+	 *   <li>上記で取得したOS一時ディレクトリのパスと生成した作業ディレクトリ名を結合し、
+	 *       新しいディレクトリを実際にファイルシステム上に作成します。
+	 *       作成されたディレクトリの {@link Path} オブジェクトは {@link #workDirectoryPath} に格納されます。</li>
+	 * </ol>
+	 * </p>
+	 *
+	 * @throws IOException ディレクトリの作成中にI/Oエラーが発生した場合。
+	 */
 	public WorkDirectoryHandler() throws IOException {
 		
 		// 作業ディレクトリ：実行時OSのTEMPディレクトリを取得
@@ -30,6 +70,16 @@ public class WorkDirectoryHandler {
 		this.workDirectoryPath = Files.createDirectory(Paths.get(tempDirectoryPath, workDirectoryName));
 	}
 	
+	/**
+	 * 作成された一時作業ディレクトリの {@link Path} オブジェクトを取得します。
+	 * <p>
+	 * このメソッドは、コンストラクタで作成された一時作業ディレクトリの完全なパスを返します。
+	 * このパスは、アプリケーションが一時ファイル（例：ZIPファイルの解凍先など）を
+	 * 保存するために使用できます。
+	 * </p>
+	 *
+	 * @return 作成された一時作業ディレクトリのパス。
+	 */
 	public Path getWorkDirectoryPath() {
 		return this.workDirectoryPath;
 	}

--- a/app/src/main/java/imaizm/imagebundler/ZipFileHandler.java
+++ b/app/src/main/java/imaizm/imagebundler/ZipFileHandler.java
@@ -12,8 +12,38 @@ import java.util.List;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 
+/**
+ * ZIPファイルの処理に関連するユーティリティメソッドを提供するクラスです。
+ * <p>
+ * 現在は、指定されたZIPファイルを解凍し、特定の条件（JPEGファイルのみ）に一致するファイルを
+ * 指定されたディレクトリに展開する機能を提供します。
+ * </p>
+ * <p>
+ * ZIPファイルのエンコーディングは "MS932" (Shift_JIS) を想定しています。
+ * </p>
+ */
 public class ZipFileHandler {
 	
+	/**
+	 * 指定されたZIPファイルを指定されたディレクトリに解凍（展開）します。
+	 * <p>
+	 * このメソッドは、ZIPファイル内のエントリを順次処理します。
+	 * ディレクトリではないエントリのうち、ファイル名が ".jpg" または ".jpeg" で終わるもの（大文字・小文字を区別しない）のみを対象とします。
+	 * 対象となったファイルは、元のファイル名を維持したまま、指定された {@code outputDirectoryPath} に展開されます。
+	 * ZIPファイルの読み込み時のエンコーディングは "MS932" (Shift_JIS) を使用します。
+	 * </p>
+	 * <p>
+	 * 注意：ZIPエントリ名にディレクトリ構造が含まれている場合（例: "folder/image.jpg"）、
+	 * 出力ファイル名はそのベース名（"image.jpg"）のみが使用され、サブディレクトリは作成されません。
+	 * </p>
+	 *
+	 * @param targetZipFilePath 解凍対象のZIPファイルのパス。
+	 * @param outputDirectoryPath 解凍されたファイルを保存するディレクトリのパス。
+	 *                            このディレクトリは事前に存在している必要があります。
+	 * @return 解凍され、出力ディレクトリに保存されたファイルの {@link Path} のリスト。
+	 *         対象となるファイル（JPG/JPEG）が存在しない場合は空のリストが返されます。
+	 * @throws IOException ZIPファイルの読み込み、またはファイルの書き出し中にI/Oエラーが発生した場合。
+	 */
 	public static List<Path> inflate(
 		Path targetZipFilePath,
 		Path outputDirectoryPath)
@@ -26,16 +56,23 @@ public class ZipFileHandler {
 			while (zipEntries.hasMoreElements()) {
 				
 				ZipArchiveEntry zipEntry = zipEntries.nextElement();
+				// ディレクトリはスキップ
 				if (! zipEntry.isDirectory()) {
-					if (zipEntry.getName().toLowerCase().endsWith("jpg") ||
-						zipEntry.getName().toLowerCase().endsWith("jpeg")) {
+					String entryNameLower = zipEntry.getName().toLowerCase();
+					// JPGまたはJPEGファイルのみを対象とする
+					if (entryNameLower.endsWith(".jpg") ||
+						entryNameLower.endsWith(".jpeg")) {
 						
+						// ZIPエントリ名からファイル名部分のみを抽出
+						// (例: "path/to/file.jpg" -> "file.jpg")
 						String outputFileName =
 							zipEntry.getName().substring(
 								zipEntry.getName().lastIndexOf("/") + 1);
 						
 						Path outputFilePath = outputDirectoryPath.resolve(outputFileName);
 						outputFilePathList.add(outputFilePath);
+						
+						// ファイルを実際に解凍して書き出す
 						try (OutputStream outputStream = Files.newOutputStream(outputFilePath)) {
 							try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
 								byte[] buffer = new byte[1024];
@@ -43,11 +80,7 @@ public class ZipFileHandler {
 								while ((readSize = inputStream.read(buffer)) != -1) {
 									outputStream.write(buffer, 0, readSize);
 								}
-							} catch (IOException e) {
-								throw e;
 							}
-						} catch (IOException e) {
-							throw e;
 						}
 					}
 				}

--- a/app/src/test/java/imaizm/imagebundler/ImageConverterTest.java
+++ b/app/src/test/java/imaizm/imagebundler/ImageConverterTest.java
@@ -12,12 +12,46 @@ import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.*;
 
+/**
+ * {@link ImageConverter} クラスのテストクラスです。
+ * <p>
+ * 主に {@link ImageConverter#convert(BufferedImage, int, int, ImageConverter.BindingSide, ImageConverter.CenterClipOption, ImageConverter.ContraAspectMode)}
+ * メソッドの様々な条件下での動作を検証します。
+ * </p>
+ */
 class ImageConverterTest {
 
 	@Nested
 	@DisplayName("convertメソッドに対するテスト")
+	/**
+	 * {@link ImageConverter#convert(BufferedImage, int, int, ImageConverter.BindingSide, ImageConverter.CenterClipOption, ImageConverter.ContraAspectMode)}
+	 * メソッドのテストケースをグループ化するネストクラスです。
+	 * <p>
+	 * 様々な入力画像、出力サイズ、および変換オプションの組み合わせに対して、
+	 * 期待される出力画像の数、サイズ、および内容（テストデータとしてファイルに保存）を検証します。
+	 * </p>
+	 */
 	class Convert {
 
+		/**
+		 * 横長の入力画像（480x320ピクセル）を、指定された出力サイズ（240x320ピクセル）に合わせて
+		 * 縦方向に2分割するテストです。
+		 * <p>
+		 * 設定：
+		 * <ul>
+		 *   <li>綴じ方向: 右 ({@link ImageConverter.BindingSide#RIGHT}) - 分割時、右側の画像がリストの最初に来る</li>
+		 *   <li>中央切り抜き: オフ ({@link ImageConverter.CenterClipOption#OFF})</li>
+		 *   <li>縦横比処理モード: 分割 ({@link ImageConverter.ContraAspectMode#SPLIT})</li>
+		 * </ul>
+		 * 期待される結果：
+		 * <ul>
+		 *   <li>2枚の画像が出力される。</li>
+		 *   <li>各画像のサイズは240x320ピクセルである。</li>
+		 *   <li>出力された画像は、指定されたパスに "01_01.jpg", "01_02.jpg" として保存される。</li>
+		 * </ul>
+		 * </p>
+		 * @throws IOException テストデータの読み込みまたは出力画像の書き込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("480x320の画像を240x320の画像２枚に縦分割(右->左)")
 		void test01_01() throws IOException {
@@ -38,6 +72,25 @@ class ImageConverterTest {
 			ImageConverter.writeJpegFile(outputImageList.get(1), outputDirPath.resolve("01_02.jpg").toAbsolutePath().toString(), 30);
 		}
 
+		/**
+		 * 横長の入力画像（480x320ピクセル）を、指定された出力サイズ（240x320ピクセル）に合わせて
+		 * 縦方向に2分割するテストです。
+		 * <p>
+		 * 設定：
+		 * <ul>
+		 *   <li>綴じ方向: 左 ({@link ImageConverter.BindingSide#LEFT}) - 分割時、左側の画像がリストの最初に来る</li>
+		 *   <li>中央切り抜き: オフ ({@link ImageConverter.CenterClipOption#OFF})</li>
+		 *   <li>縦横比処理モード: 分割 ({@link ImageConverter.ContraAspectMode#SPLIT})</li>
+		 * </ul>
+		 * 期待される結果：
+		 * <ul>
+		 *   <li>2枚の画像が出力される。</li>
+		 *   <li>各画像のサイズは240x320ピクセルである。</li>
+		 *   <li>出力された画像は、指定されたパスに "02_01.jpg", "02_02.jpg" として保存される。</li>
+		 * </ul>
+		 * </p>
+		 * @throws IOException テストデータの読み込みまたは出力画像の書き込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("480x320の画像を240x320の画像２枚に縦分割(左->右)")
 		void test01_02() throws IOException {
@@ -58,6 +111,25 @@ class ImageConverterTest {
 			ImageConverter.writeJpegFile(outputImageList.get(1), outputDirPath.resolve("02_02.jpg").toAbsolutePath().toString(), 30);
 		}
 
+		/**
+		 * 横長の入力画像（480x320ピクセル）を、指定された出力サイズ（120x160ピクセル）に合わせて
+		 * 縦方向に2分割するテストです。このケースでは、出力画像の縦横比が入力画像の半分（分割後）の縦横比と等しくなります。
+		 * <p>
+		 * 設定：
+		 * <ul>
+		 *   <li>綴じ方向: 左 ({@link ImageConverter.BindingSide#LEFT})</li>
+		 *   <li>中央切り抜き: オフ ({@link ImageConverter.CenterClipOption#OFF})</li>
+		 *   <li>縦横比処理モード: 分割 ({@link ImageConverter.ContraAspectMode#SPLIT})</li>
+		 * </ul>
+		 * 期待される結果：
+		 * <ul>
+		 *   <li>2枚の画像が出力される。</li>
+		 *   <li>各画像のサイズは120x160ピクセルである（アスペクト比を維持して縮小される）。</li>
+		 *   <li>出力された画像は、指定されたパスに "03_01.jpg", "03_02.jpg" として保存される。</li>
+		 * </ul>
+		 * </p>
+		 * @throws IOException テストデータの読み込みまたは出力画像の書き込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("480x320の画像を120x160の画像２枚に縦分割(指定サイズは120x160=等アスペクト比)")
 		void test01_03() throws IOException {
@@ -78,6 +150,27 @@ class ImageConverterTest {
 			ImageConverter.writeJpegFile(outputImageList.get(1), outputDirPath.resolve("03_02.jpg").toAbsolutePath().toString(), 30);
 		}
 		
+		/**
+		 * 横長の入力画像（480x320ピクセル）を、指定された出力サイズ（幅120ピクセル、高さ320ピクセル）に合わせて
+		 * 縦方向に2分割するテストです。このケースでは、出力画像の縦横比が入力画像の半分（分割後）の縦横比と異なります。
+		 * <p>
+		 * 設定：
+		 * <ul>
+		 *   <li>綴じ方向: 左 ({@link ImageConverter.BindingSide#LEFT})</li>
+		 *   <li>中央切り抜き: オフ ({@link ImageConverter.CenterClipOption#OFF})</li>
+		 *   <li>縦横比処理モード: 分割 ({@link ImageConverter.ContraAspectMode#SPLIT})</li>
+		 * </ul>
+		 * 期待される結果：
+		 * <ul>
+		 *   <li>2枚の画像が出力される。</li>
+		 *   <li>各画像のサイズは120x160ピクセルである。
+		 *       これは、入力画像（分割後240x320）を、指定された出力幅120に合わせてアスペクト比を維持して縮小した結果です。
+		 *       （高さは320が指定されているが、アスペクト比維持のため160になる）</li>
+		 *   <li>出力された画像は、指定されたパスに "04_01.jpg", "04_02.jpg" として保存される。</li>
+		 * </ul>
+		 * </p>
+		 * @throws IOException テストデータの読み込みまたは出力画像の書き込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("480x320の画像を120x160の画像２枚に縦分割(指定サイズは120x320=不等アスペクト比)")
 		void test01_04() throws IOException {
@@ -98,6 +191,25 @@ class ImageConverterTest {
 			ImageConverter.writeJpegFile(outputImageList.get(1), outputDirPath.resolve("04_02.jpg").toAbsolutePath().toString(), 30);
 		}
 		
+		/**
+		 * 横長の入力画像（480x320ピクセル）を、指定された出力サイズ（320x480ピクセル）に合わせて
+		 * 反時計回りに90度回転させるテストです。
+		 * <p>
+		 * 設定：
+		 * <ul>
+		 *   <li>綴じ方向: 左 ({@link ImageConverter.BindingSide#LEFT}) - このテストでは影響しない</li>
+		 *   <li>中央切り抜き: オフ ({@link ImageConverter.CenterClipOption#OFF}) - このテストでは影響しない</li>
+		 *   <li>縦横比処理モード: 回転 ({@link ImageConverter.ContraAspectMode#ROTATE})</li>
+		 * </ul>
+		 * 期待される結果：
+		 * <ul>
+		 *   <li>1枚の画像が出力される。</li>
+		 *   <li>画像のサイズは320x480ピクセルである（入力画像を回転させ、指定サイズにリサイズ）。</li>
+		 *   <li>出力された画像は、指定されたパスに "05.jpg" として保存される。</li>
+		 * </ul>
+		 * </p>
+		 * @throws IOException テストデータの読み込みまたは出力画像の書き込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("480x320の画像を反時計回りに90°回転させ320x480の画像に変換")
 		void test01_05() throws IOException {
@@ -115,6 +227,25 @@ class ImageConverterTest {
 			ImageConverter.writeJpegFile(outputImageList.get(0), outputDirPath.resolve("05.jpg").toAbsolutePath().toString(), 30);
 		}
 
+		/**
+		 * 縦長の入力画像（320x480ピクセル）を、指定された出力サイズ（320x240ピクセル）に合わせて
+		 * 横方向に2分割するテストです。
+		 * <p>
+		 * 設定：
+		 * <ul>
+		 *   <li>綴じ方向: 右 ({@link ImageConverter.BindingSide#RIGHT}) - このテストでは影響しない（横分割のため）</li>
+		 *   <li>中央切り抜き: オフ ({@link ImageConverter.CenterClipOption#OFF})</li>
+		 *   <li>縦横比処理モード: 分割 ({@link ImageConverter.ContraAspectMode#SPLIT})</li>
+		 * </ul>
+		 * 期待される結果：
+		 * <ul>
+		 *   <li>2枚の画像が出力される。</li>
+		 *   <li>各画像のサイズは320x240ピクセルである。リストの最初の画像が元画像の上半分、2番目が下半分に対応する。</li>
+		 *   <li>出力された画像は、指定されたパスに "01_01.jpg", "01_02.jpg" として保存される。</li>
+		 * </ul>
+		 * </p>
+		 * @throws IOException テストデータの読み込みまたは出力画像の書き込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("320x480の画像を320x240の画像２枚に横分割(上->下)")
 		void test02() throws IOException {
@@ -122,7 +253,7 @@ class ImageConverterTest {
 			Path inputFilePath = testDataPath.resolve("320x480.jpg");
 			BufferedImage inputImage = ImageIO.read(inputFilePath.toFile());
 			List<BufferedImage> outputImageList = ImageConverter.convert(inputImage, 320, 240,
-				ImageConverter.BindingSide.RIGHT,
+				ImageConverter.BindingSide.RIGHT, // 横分割の場合、綴じ方向は影響しない
 				ImageConverter.CenterClipOption.OFF,
 				ImageConverter.ContraAspectMode.SPLIT);
 			assertAll("outputImageList-width-height",

--- a/app/src/test/java/imaizm/imagebundler/IniFileHandlerTest.java
+++ b/app/src/test/java/imaizm/imagebundler/IniFileHandlerTest.java
@@ -11,23 +11,61 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.*;
 
+/**
+ * {@link IniFileHandler} クラスのテストクラスです。
+ * <p>
+ * 主に {@link IniFileHandler#IniFileHandler()} コンストラクタと
+ * {@link IniFileHandler#writeWorkDirectoryOfLastTime(String)} メソッドの動作を、
+ * 様々な条件下で検証します。特に、INIファイルの存在有無や内容、
+ * およびシステムプロパティ "user.dir" の設定がテスト結果に与える影響を確認します。
+ * </p>
+ */
 class IniFileHandlerTest {
 
 	@Nested
 	@DisplayName("コンストラクタに対するテスト")
+	/**
+	 * {@link IniFileHandler#IniFileHandler()} コンストラクタのテストケースをグループ化するネストクラスです。
+	 */
 	class Constructor {
 
 		@Nested
 		@DisplayName("システムプロパティ「user.dir」を変更するテストケース群")
+		/**
+		 * システムプロパティ "user.dir" (カレントワーキングディレクトリ) の値を変更して
+		 * {@link IniFileHandler} のコンストラクタの動作をテストするケースをグループ化します。
+		 * <p>
+		 * 各テストの前後で "user.dir" の値を保存・復元することで、テスト間の影響を排除します。
+		 * </p>
+		 */
 		class CasesOfSetUserDirSystemProperty {
 			
+			/** テスト実行前の "user.dir" システムプロパティの値を保持します。 */
 			private String originalUserDir;
 			
+			/**
+			 * 各テストメソッドの実行前に呼び出されます。
+			 * 現在の "user.dir" システムプロパティの値を {@link #originalUserDir} に保存します。
+			 */
 			@BeforeEach
 			void beforeEach() {
 				this.originalUserDir = System.getProperty("user.dir");
 			}
 			
+			/**
+			 * INIファイルが存在し、その中に記録されている前回実行ディレクトリのパスが実在する場合のテストです。
+			 * <p>
+			 * 手順：
+			 * <ol>
+			 *   <li>"user.dir" をテストデータ用のパスに設定します。</li>
+			 *   <li>テストデータパス直下に "ImageBundler.ini" を作成し、テストデータパス自身を書き込みます。</li>
+			 *   <li>{@link IniFileHandler} をインスタンス化します。</li>
+			 *   <li>{@link IniFileHandler#getWorkDirectoryPathOfLastTime()} がINIファイルに書き込んだパスと等しいことを表明します。</li>
+			 *   <li>作成したINIファイルを削除します。</li>
+			 * </ol>
+			 * </p>
+			 * @throws IOException テストファイルの作成または削除、INIファイルの読み書き中にエラーが発生した場合。
+			 */
 			@Test
 			@DisplayName("iniファイルが存在するケース(前回実行dirが実在path)")
 			void test01() throws IOException {
@@ -49,6 +87,25 @@ class IniFileHandlerTest {
 				Files.delete(tempIniFile);
 			}
 			
+			/**
+			 * INIファイルが存在し、その中に記録されている前回実行ディレクトリのパスが、
+			 * 実在するパスと実在しないパスの組み合わせである場合のテストです。
+			 * （例： `/actual_path/non_existent_path1/non_existent_path2`）
+			 * <p>
+			 * 手順：
+			 * <ol>
+			 *   <li>"user.dir" をテストデータ用のパスに設定します。</li>
+			 *   <li>テストデータパス直下に "ImageBundler.ini" を作成し、
+			 *       テストデータパスの下に存在しないサブディレクトリ "aaa/bbb" を含むパスを書き込みます。</li>
+			 *   <li>{@link IniFileHandler} をインスタンス化します。</li>
+			 *   <li>{@link IniFileHandler#getWorkDirectoryPathOfLastTime()} が、
+			 *       INIファイルに書き込んだパスのうち、実際に存在する最も深い階層のパス（この場合はテストデータパス自身）
+			 *       と等しいことを表明します。</li>
+			 *   <li>作成したINIファイルを削除します。</li>
+			 * </ol>
+			 * </p>
+			 * @throws IOException テストファイルの作成または削除、INIファイルの読み書き中にエラーが発生した場合。
+			 */
 			@Test
 			@DisplayName("iniファイルが存在するケース(前回実行dirが実在path+非実在path)")
 			void test02() throws IOException {
@@ -74,6 +131,23 @@ class IniFileHandlerTest {
 				Files.delete(tempIniFile);
 			}
 
+			/**
+			 * INIファイルが存在しない場合のテストです。
+			 * <p>
+			 * 手順：
+			 * <ol>
+			 *   <li>"user.dir" をテストデータ用のパスに設定します。</li>
+			 *   <li>テストデータパス直下に "ImageBundler.ini" が存在しないことを確認します。</li>
+			 *   <li>{@link IniFileHandler} をインスタンス化します。</li>
+			 *   <li>{@link IniFileHandler#getWorkDirectoryPathOfLastTime()} が null であることを表明します（INIファイルが存在しなかったため）。</li>
+			 *   <li>コンストラクタの実行により、"ImageBundler.ini" が空のファイルとして新規作成されたことを表明します。</li>
+			 *   <li>{@link IniFileHandler#writeWorkDirectoryOfLastTime(String)} を使用してテストデータパスをINIファイルに書き込みます。</li>
+			 *   <li>INIファイルを読み込み、書き込まれた内容がテストデータパスと一致することを表明します。</li>
+			 *   <li>作成したINIファイルを削除します。</li>
+			 * </ol>
+			 * </p>
+			 * @throws IOException テストファイルの作成または削除、INIファイルの読み書き中にエラーが発生した場合。
+			 */
 			@Test
 			@DisplayName("iniファイルが存在しないケース")
 			void test03() throws IOException {
@@ -102,6 +176,10 @@ class IniFileHandlerTest {
 				Files.delete(tempIniFile);
 			}
 
+			/**
+			 * 各テストメソッドの実行後に呼び出されます。
+			 * "user.dir" システムプロパティの値を、テスト実行前に保存した元の値 ({@link #originalUserDir}) に復元します。
+			 */
 			@AfterEach
 			void afterEach() {
 				System.setProperty("user.dir", this.originalUserDir);

--- a/app/src/test/java/imaizm/imagebundler/InputFileHandlerTest.java
+++ b/app/src/test/java/imaizm/imagebundler/InputFileHandlerTest.java
@@ -17,12 +17,35 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+/**
+ * {@link InputFileHandler} クラスのテストクラスです。
+ * <p>
+ * 主に {@link InputFileHandler#InputFileHandler(Path)} コンストラクタと
+ * {@link InputFileHandler#close()} メソッドの動作を、様々な入力条件のもとで検証します。
+ * </p>
+ */
 public class InputFileHandlerTest {
 	
 	@Nested
 	@DisplayName("コンストラクタに対するテスト")
+	/**
+	 * {@link InputFileHandler#InputFileHandler(Path)} コンストラクタのテストケースをグループ化するネストクラスです。
+	 * <p>
+	 * 入力対象がディレクトリの場合、ZIPファイルの場合、未対応ファイルの場合、
+	 * およびファイル拡張子の大文字・小文字の区別に関してテストを行います。
+	 * </p>
+	 */
 	class Constructor {
 	
+		/**
+		 * 入力対象がディレクトリの場合の {@link InputFileHandler} のコンストラクタのテストです。
+		 * <p>
+		 * 指定されたディレクトリ内に存在するサポート対象の画像ファイル（.jpg, .jpeg, .png）が
+		 * 正しく認識され、リストアップされることを確認します。
+		 * サポート対象外のファイル（.gif）が含まれていないことも確認します。
+		 * </p>
+		 * @throws IOException テストデータの読み込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("対象：ディレクトリ")
 		void test01() throws IOException {
@@ -40,6 +63,19 @@ public class InputFileHandlerTest {
 				() -> assertFalse(inputFileNameList.contains("480x320.gif")));
 		}
 		
+		/**
+		 * 入力対象がZIPファイルの場合の {@link InputFileHandler} のコンストラクタおよび {@link InputFileHandler#close()} メソッドのテストです。
+		 * <p>
+		 * 指定されたZIPファイルが正しく解凍され、サポート対象の画像ファイル（.jpg, .jpeg）が
+		 * 処理対象としてリストアップされることを確認します。
+		 * ZIPファイル内にPNGファイルも含まれていますが、現在のテストコードではコメントアウトされており、
+		 * PNGが処理対象に含まれない（または含まれるべきだがテストされていない）状態であることを示唆しています。
+		 * サポート対象外のファイル（.gif）がリストアップされていないことも確認します。
+		 * さらに、{@link InputFileHandler#close()} メソッド呼び出し後に、解凍に使用された一時ディレクトリが
+		 * 適切に削除されることを検証します。
+		 * </p>
+		 * @throws IOException テストデータの読み込み、ZIPファイルの解凍、または一時ディレクトリの操作中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("対象：zipファイル")
 		void test02() throws IOException {
@@ -53,7 +89,7 @@ public class InputFileHandlerTest {
 			assertAll("inputFiles",
 				() -> assertTrue(inputFileNameList.contains("480x320.jpg")),
 				() -> assertTrue(inputFileNameList.contains("480x320.jpeg")),
-			//	() -> assertTrue(inputFileNameList.contains("480x320.png")),
+			//	() -> assertTrue(inputFileNameList.contains("480x320.png")), // ZipFileHandlerは現状JPG/JPEGのみ対応
 				() -> assertFalse(inputFileNameList.contains("480x320.gif")));
 			Path extractDirectoryPath = inputFileHandler.getExtractDirectoryPath();
 			List<String> beforeDeleteList =
@@ -63,13 +99,22 @@ public class InputFileHandlerTest {
 			assertAll("extractedFiles",
 					() -> assertTrue(beforeDeleteList.contains("480x320.jpg")),
 					() -> assertTrue(beforeDeleteList.contains("480x320.jpeg")),
-				//	() -> assertTrue(beforeDeleteList.contains("480x320.png")),
+				//	() -> assertTrue(beforeDeleteList.contains("480x320.png")), // ZipFileHandlerは現状JPG/JPEGのみ対応
 					() -> assertFalse(beforeDeleteList.contains("480x320.gif")));
 			
 			inputFileHandler.close();
 			assertTrue(Files.notExists(extractDirectoryPath));
 		}
 		
+		/**
+		 * 入力対象がサポートされていないファイル形式（この場合は .txt ファイル）の場合の
+		 * {@link InputFileHandler} のコンストラクタのテストです。
+		 * <p>
+		 * 未対応のファイル形式が指定された場合に、期待通り {@link RuntimeException} がスローされ、
+		 * その例外メッセージが "未対応のファイル形式です。" であることを確認します。
+		 * </p>
+		 * @throws IOException テストデータの読み込み中にエラーが発生した場合（このテストでは通常発生しない）。
+		 */
 		@Test
 		@DisplayName("対象：未対応ファイル")
 		void test03() throws IOException {
@@ -81,6 +126,17 @@ public class InputFileHandlerTest {
 			assertEquals(e.getMessage(), "未対応のファイル形式です。");
 		}
 
+		/**
+		 * 入力対象がディレクトリの場合で、ファイル拡張子が大文字・小文字混合である場合の
+		 * {@link InputFileHandler} のコンストラクタのテストです。
+		 * <p>
+		 * ファイル拡張子が大文字（.JPG, .JPEG, .PNG）であっても、
+		 * 正しくサポート対象の画像ファイルとして認識され、リストアップされることを確認します。
+		 * サポート対象外のファイル（.GIF）が含まれていないことも確認します。
+		 * これは、ファイル拡張子のマッチングがケースインセンシティブに行われることを検証するものです。
+		 * </p>
+		 * @throws IOException テストデータの読み込み中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("対象：ディレクトリ（拡張子の大文字小文字区別なし確認）")
 		void test04() throws IOException {

--- a/app/src/test/java/imaizm/imagebundler/ZipFileHandlerTest.java
+++ b/app/src/test/java/imaizm/imagebundler/ZipFileHandlerTest.java
@@ -11,12 +11,43 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.*;
 
+/**
+ * {@link ZipFileHandler} クラスのテストクラスです。
+ * <p>
+ * 主に {@link ZipFileHandler#inflate(Path, Path)} メソッドの動作を検証します。
+ * </p>
+ */
 class ZipFileHandlerTest {
 	
 	@Nested
 	@DisplayName("inflateメソッドに対するテスト")
+	/**
+	 * {@link ZipFileHandler#inflate(Path, Path)} メソッドのテストケースをグループ化するネストクラスです。
+	 */
 	class Inflate {
 
+		/**
+		 * {@link ZipFileHandler#inflate(Path, Path)} メソッドが、指定されたZIPファイルを正しく解凍し、
+		 * JPEGファイルのみを展開することを確認するテストです。
+		 * <p>
+		 * 手順：
+		 * <ol>
+		 *   <li>テスト用のZIPファイル (data.zip) と、解凍先の一時ディレクトリ (inflated) を準備します。</li>
+		 *   <li>{@code ZipFileHandler.inflate} メソッドを呼び出し、ZIPファイルを解凍します。</li>
+		 *   <li>解凍されたファイル名のリストを取得し、以下の点を確認します：
+		 *     <ul>
+		 *       <li>"480x320.jpg" が含まれていること。</li>
+		 *       <li>"480x320.jpeg" が含まれていること。</li>
+		 *       <li>"480x320.png" が含まれていないこと（現状のZipFileHandlerはJPG/JPEGのみを対象とするため）。
+		 *           テストコード内ではこのアサーションはコメントアウトされています。</li>
+		 *       <li>"480x320.gif" が含まれていないこと。</li>
+		 *     </ul>
+		 *   </li>
+		 *   <li>テスト後、解凍された個々のファイルと一時ディレクトリを削除します。</li>
+		 * </ol>
+		 * </p>
+		 * @throws IOException テストファイルの準備、ZIPファイルの解凍、または一時ファイルの削除中にエラーが発生した場合。
+		 */
 		@Test
 		@DisplayName("実際にZipファイルを解凍し中身を確認するテスト")
 		void test01() throws IOException {
@@ -32,7 +63,7 @@ class ZipFileHandlerTest {
 				assertAll("inputFiles",
 					() -> assertTrue(inflatedFileNameList.contains("480x320.jpg")),
 					() -> assertTrue(inflatedFileNameList.contains("480x320.jpeg")),
-				//	() -> assertTrue(inflatedFileNameList.contains("480x320.png")),
+				//	() -> assertTrue(inflatedFileNameList.contains("480x320.png")), // ZipFileHandlerは現状JPG/JPEGのみ対応
 					() -> assertFalse(inflatedFileNameList.contains("480x320.gif")));
 				
 				for (Path inflatedFilePath : inflatedFilePathList) {


### PR DESCRIPTION
…しました。

また、既存のコメントについても、内容の正確性を確認し、必要に応じて修正または日本語に翻訳しました。

主な変更点：
- 各クラス、メソッド、主要なフィールドに対して、その目的、動作、引数、返り値などを説明するJavadocコメントを整備しました。
- 既存の単行コメントや誤解を招く可能性のあるコメントを修正・削除し、Javadocに情報を集約しました。
- コメント内の専門用語や処理内容が、より明確かつ理解しやすくなるように配慮しました。
- 一部のコード（ImageConverter.java, EntryPoint.java）で、マジックナンバーを定数に置き換えるなど、可読性向上のための軽微なリファクタリングも合わせて実施しました。

これにより、コードの保守性と可読性が向上し、将来の機能追加や改修が容易になることが期待されます。